### PR TITLE
Stateful sha512

### DIFF
--- a/rsa_cpp/rsa.cpp
+++ b/rsa_cpp/rsa.cpp
@@ -7,7 +7,12 @@
 int main()
 {
 	constexpr const std::uint8_t message[] = "Hello World!";
-	const std::array<std::uint8_t, 512 / 8> hash_bytes = sha512::calculate_hash(message, sizeof(message) - 1);
+	sha512::digest_t hash_bytes;
+	{
+		sha512 hash;
+		hash.update(message, sizeof(message) - 1);
+		hash_bytes = hash.digest();
+	}
 	for (const std::uint8_t& byte_elem : hash_bytes)
 	{
 		std::ostringstream num_as_str;

--- a/rsa_cpp/rsa_cpp.vcxproj
+++ b/rsa_cpp/rsa_cpp.vcxproj
@@ -29,26 +29,26 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>ClangCL</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>ClangCL</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>ClangCL</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>ClangCL</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>

--- a/rsa_cpp/rsa_cpp.vcxproj
+++ b/rsa_cpp/rsa_cpp.vcxproj
@@ -31,6 +31,7 @@
     <UseDebugLibraries>true</UseDebugLibraries>
     <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
+    <EnableASAN>true</EnableASAN>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
@@ -38,12 +39,14 @@
     <PlatformToolset>v142</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
+    <EnableASAN>true</EnableASAN>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
     <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
+    <EnableASAN>true</EnableASAN>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
@@ -51,6 +54,7 @@
     <PlatformToolset>v142</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
+    <EnableASAN>true</EnableASAN>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">

--- a/rsa_cpp/sha512.cpp
+++ b/rsa_cpp/sha512.cpp
@@ -9,89 +9,43 @@
 // SHA512, the largest message that SHA512 supports is of size 2^128-1 bits
 // which I assume to never receive as part of this function.
 
-void sha512::update(const std::uint8_t* const message, const std::size_t len)
+void sha512::update(const std::uint8_t* const data, const std::size_t len)
 {
-	if (message == nullptr)
+	if (data == nullptr)
 	{
 		throw std::invalid_argument("Error in function \"sha512::update\""
-			" \"message\" can\'t be nullptr");
+			" \"data\" can\'t be nullptr");
 	}
 	if (len <= 0)
 	{
 		throw std::invalid_argument("Error in function \"sha512::update\"."
 			" \"len\" can\'t be 0");
 	}
-	// Times 8 to convert from bytes to bits
-	this->m_bits_counter += static_cast<decltype(this->m_bits_counter)>(len) << 3;
+	if (this->m_num_bytes_filled < 0 || this->m_num_bytes_filled > sha512::message_block_size_bytes)
 	{
-
+		throw std::logic_error("Error in function \"sha512::update\"."
+			" \"this->m_num_bytes_filled\" is out of range.");
+	}
+	for (std::size_t index_in_data = 0; index_in_data < len; )
+	{
+		// Compress if needed
 		{
-			// A boolean for whether the terminating 1 bit got put in the
-			// current_block or whether there was not room and it got
-			// posponed to the next block.
-			bool bit_postponed = false;
-			int index_of_terminating_1_in_64bit_arr = 0;
-
-			std::size_t message_index = 0;
-
-			for (; ; message_index += blocks_size_bytes)
+			const int num_bytes_unfilled_in_message_block = sha512::message_block_size_bytes - this->m_num_bytes_filled;
+			if (num_bytes_unfilled_in_message_block == 0)
 			{
-				const std::size_t bytes_remaining = len - message_index;
-				if (bytes_remaining >= blocks_size_bytes)
-				{
-					// Loading as big-endian
-					sha512::copy_arr_bytes_into_arr_64_bits(&message[message_index], blocks_size_bytes, current_block.data());
-					sha512::SHA512_compress(current_block, current_hash_values);
-				}
-				if (bytes_remaining == blocks_size_bytes)
-				{
-					// Didn't put in the last 1 bit
-					bit_postponed = true;
-					break;
-				}
-				// If it's not exactly 128 bits then there's room for the 1 terminating bit
-				// in the current block.
-				else if (bytes_remaining < blocks_size_bytes)
-				{
-					const int index_of_terminating_1_in_current_block = bytes_remaining / 8;
-					std::fill(current_block.begin() + index_of_terminating_1_in_current_block, current_block.end(), 0);
-					// Loading as big-endian
-					sha512::copy_arr_bytes_into_arr_64_bits(&message[message_index], bytes_remaining, current_block.data());
-					//the index byte in 64 bits
-					const int index_byte = bytes_remaining % 8;
-					// Set the 1 terminating bit
-					current_block[index_of_terminating_1_in_current_block] |= static_cast<std::uint64_t>(1) << (63 - (index_byte * 8));
-					index_of_terminating_1_in_64bit_arr = index_of_terminating_1_in_current_block;
-					bit_postponed = false;
-					break;
-				}
-			}
-
-			if (bit_postponed)
-			{
-				std::fill(current_block.begin(), current_block.end(), 0);
-				current_block[0] = static_cast<std::uint64_t>(1) << 63;
-			}
-			// If the terminating 1 takes up one of the last two 64-bit elements in current_block,
-			// then the length is pushed to the next block. That's because there are 128 bits
-			// reserved for the length of the message in bits.
-			else if (index_of_terminating_1_in_64bit_arr >= static_cast<int>(current_block.size()) - 2)
-			{
-				sha512::SHA512_compress(current_block, current_hash_values);
-				std::fill(current_block.begin(), current_block.end(), 0);
+				sha512::compress(this->m_message_block, m_hash_values);
+				this->m_num_bytes_filled = 0;
 			}
 		}
-		// The "std::uint64_t"s exist inside of "current_block" in the machine native form.
-		// That's why endianness is irrelevant here.
-		// boost::endian::conditional_reverse(len, boost::endian::order::native, boost::endian::order::big);
-		static_assert(std::is_unsigned<decltype(len)>::value,
-			"I need the \"len\" variable to be unsigned because left-shifting a signed integer is undefined behaviour.");
-		constexpr int num_bits_in_len = std::numeric_limits<decltype(len)>::digits;
-		static_assert(num_bits_in_len <= 64, "Too many bits in std::size_t. We now need to change the code to account for that.");
-		current_block[current_block.size() - 1] = static_cast<std::uint64_t>(static_cast<std::uint64_t>(len) << 3 /*times 8, from bytes to bits*/);
-		current_block[current_block.size() - 2] = static_cast<std::uint64_t>(static_cast<std::uint64_t>(len) >> (64 - 3) /*The overflow bits from earlier*/);
-		sha512::SHA512_compress(current_block, current_hash_values);
+		const int num_bytes_unfilled_in_message_block = sha512::message_block_size_bytes - this->m_num_bytes_filled;
+		const std::size_t num_bytes_remaining_in_data = len - index_in_data;
+		const int bytes_to_copy = static_cast<int>(std::min<std::size_t>(num_bytes_remaining_in_data, static_cast<std::size_t>(num_bytes_unfilled_in_message_block)));
+		sha512::copy_arr_bytes_into_message_block(&data[index_in_data], bytes_to_copy, this->m_message_block, this->m_num_bytes_filled);
+		this->m_num_bytes_filled += bytes_to_copy;
+		index_in_data += bytes_to_copy;
 	}
+	// Times 8 to convert from bytes to bits
+	this->m_bits_counter += static_cast<decltype(this->m_bits_counter)>(len) << 3;
 }
 
 void sha512::zero_bytes(message_block_t& messsage_block, int index_byte_to_start_zeroing)
@@ -104,14 +58,14 @@ void sha512::zero_bytes(message_block_t& messsage_block, int index_byte_to_start
 	const int index_uint64 = index_byte_to_start_zeroing / 8;
 	// One of the elements of message_block is tricky because part of it is already used
 	// so we only need to clear the end of it in big endian byte order, meaning there's
-	// one bit where zeroing the memory is not good and therefore we need to use
+	// one uint64 where zeroing the memory is not good and therefore we need to use
 	// bit manipulation to zero only the least significant part of the uint64_t.
 	// I'll call that element in message_block: "junction_uint64"
 	{
 		auto clear_n_least_significant_bits = [](const std::uint64_t& num, const int num_bits_to_clear) -> std::uint64_t
 		{
 			// Don't bit shift by 64 bits or more, that would be undefined behavior in C++
-			if (num_bits_to_clear > 64)
+			if (num_bits_to_clear >= 64)
 				return 0;
 			else
 				return static_cast<std::uint64_t>(num >> num_bits_to_clear) << num_bits_to_clear;
@@ -159,7 +113,7 @@ sha512::digest_t sha512::digest() const
 		// 1000000010000000100000001000000010000000100000001000000010000000
 		// The convention we're using for SHA512 revolves around 8-bit bytes, not bits.
 		{
-			const int index_byte_of_1_bit = num_bytes_filled + 1;
+			const int index_byte_of_1_bit = num_bytes_filled;
 			const int index_uint64_of_1_bit = index_byte_of_1_bit / 8;
 			// Where index 0 is the most significant
 			// in big-endian style.
@@ -198,33 +152,52 @@ sha512::digest_t sha512::digest() const
 	// We'll convert the hash to bytes to avoid
 	// confusion over endianness.
 
-	sha512::digest_t hash_user_friendly;
+	sha512::digest_t hash_user_friendly{ { 0 } };
 	for (int index = 0; index < static_cast<int>(final_hash.size()); ++index)
 	{
-		boost::endian::store_big_u64(hash_user_friendly.data() + index * 8, final_hash[index]);
+		boost::endian::store_big_u64(hash_user_friendly.data() + index * 8LL, final_hash[index]);
 	}
 	return hash_user_friendly;
 }
 
 // Loading the bytes into the std::uint64 as big endian because
 // that's the convention when dealing with SHA512
- void sha512::copy_arr_bytes_into_arr_64_bits(const std::uint8_t* const bytes, const std::size_t num_bytes, std::uint64_t* const arr64, const int num_bytes_already_taken)
+//
+// For example
+// When calling the function "copy_arr_bytes_into_message_block" with
+// the parameters:
+//		bytes == { 0x01, 0x02, 0x03 },
+//		num_bytes == 2,
+//		message_block == { 1, 2, 3, 4, 5, 6, 7, 0xffffffffffffffff, 99, 99, 99, 99, 99, 99, 99, 99 },
+//		num_bytes_already_used_in_message_block == 56
+// Then message_block will become:
+//		 message_block = { 1, 2, 3, 4, 5, 6, 7, 0x0102ffffffffffff, 99, 99, 99, 99, 99, 99, 99, 99 },
+//
+void sha512::copy_arr_bytes_into_message_block(const std::uint8_t* const bytes, const int num_bytes, message_block_t& messsage_block, const int num_bytes_already_used_in_message_block)
 {
-	const bool bytes_taken_valid_range = num_bytes_already_taken >= 0 && num_bytes_already_taken < 8;
+	const bool bytes_taken_valid_range = num_bytes_already_used_in_message_block >= 0 && num_bytes_already_used_in_message_block < sha512::message_block_size_bytes;
 	if (!bytes_taken_valid_range)
 	{
 		throw std::invalid_argument("Error in function \"sha512::copy_arr_bytes_into_arr_64_bits\"."
-			" num_bytes_already_taken is out of range [0, 8)");
+			" \"num_bytes_already_used_in_message_block\" is out of range [0, 128)");
 	}
 	if (num_bytes <= 0)
 	{
 		throw std::invalid_argument("Error in function \"sha512::copy_arr_bytes_into_arr_64_bits\"."
 			" num_bytes can\'t be zero.");
 	}
-	if (bytes == nullptr || arr64 == nullptr)
+	if (bytes == nullptr)
 	{
 		throw std::invalid_argument("Error in function \"sha512::copy_arr_bytes_into_arr_64_bits\"."
 			" neither \"bytes\" nor \"arr64\" are allowed to be nullptr.");
+	}
+	{
+		const int num_bytes_left_in_message_block = sha512::message_block_size_bytes - num_bytes_already_used_in_message_block;
+		if (num_bytes > num_bytes_left_in_message_block)
+		{
+			throw std::invalid_argument("Error in function \"sha512::copy_arr_bytes_into_arr_64_bits\"."
+				" There isn\'t enough room in the message block to copy the requested number of bytes.");
+		}
 	}
 
 	// The copying is very simple. Use boost::endian::load_big_u64 each time to copy
@@ -239,28 +212,66 @@ sha512::digest_t sha512::digest() const
 	// implement specialized bitwise operations that don't override the existing data.
 	//
 
-	// Check the first index
+	// Lambda function "fill_byte_in_index":
+	// Index byte where 0 is the most significant byte and 7 is the least significant byte.
+	// In big-endian style.
+	//
+	// Example:
+	// Calling with:
+	// num == 0x123456789abcdef0, byte == 0x01, index_byte == 1
+	// 
+	// sets num = 0x120156789abcdef0
+	//
+	auto fill_byte_in_index = [](std::uint64_t& num, const std::uint8_t& byte, const int& index_byte)
 	{
-
-	}
-
-	if (num_bytes > 0)
-	{
-		std::array<std::uint8_t, 8> emergency_buffer{ {0} };
-		std::size_t index_byte = 0;
-		std::size_t index_arr = 0;
-		for (; ; index_byte += 8, ++index_arr)
+		// The "index_byte" must be in the range [0, 7] otherwise it causes
+		// undefined behavior.
+		if (index_byte < 0 || index_byte > 7)
 		{
-			const std::size_t bytes_remaining = num_bytes - index_byte;
+			throw std::invalid_argument("Error in lambda function \"fill_byte_in_index\"."
+				" The requested byte index in the uint64 is outside of the range [0, 7]");
+		}
+		const int amount_shift_left = ((7 - index_byte) * 8);
+		// Clear the target byte
+		num &= ~(static_cast<std::uint64_t>(0xff) << amount_shift_left);
+		// Set the target byte (target byte must already by zeroed, that's why we cleared it just above).
+		num |= static_cast<std::uint64_t>(byte) << amount_shift_left;
+	};
+
+	int index_in_arr64 = num_bytes_already_used_in_message_block / 8;
+	int num_bytes_already_taken_in_first_uint64 = num_bytes_already_used_in_message_block % 8;
+	int index_byte = 0;
+
+	// Do the first index
+	{
+		const int unused_bytes_in_first_uint64 = 8 - num_bytes_already_taken_in_first_uint64;
+		const int num_bytes_to_fill_in_in_first_uint64 = std::min<int>(num_bytes, unused_bytes_in_first_uint64);
+		if (num_bytes_to_fill_in_in_first_uint64 > 0)
+		{
+			for (index_byte = 0; index_byte < num_bytes_to_fill_in_in_first_uint64; ++index_byte)
+			{
+				fill_byte_in_index(messsage_block[index_in_arr64], bytes[index_byte], num_bytes_already_taken_in_first_uint64 + index_byte);
+			}
+			++index_in_arr64;
+		}
+	}
+	// Copy normally
+	if (index_byte < num_bytes)
+	{
+		for (; ; index_byte += 8, ++index_in_arr64)
+		{
+			const int bytes_remaining = num_bytes - index_byte;
 			if (bytes_remaining >= 8)
 			{
-				arr64[index_arr] = boost::endian::load_big_u64(&bytes[index_byte]);
+				messsage_block[index_in_arr64] = boost::endian::load_big_u64(&bytes[index_byte]);
 			}
+			// Do the last index in the arr64
 			if (bytes_remaining < 8)
 			{
-				std::fill(emergency_buffer.begin(), emergency_buffer.end(), 0);
-				std::copy_n(&bytes[index_byte], bytes_remaining, emergency_buffer.begin());
-				arr64[index_arr] = boost::endian::load_big_u64(emergency_buffer.data());
+				for (int bytes_counter = 0; bytes_counter < bytes_remaining; ++bytes_counter)
+				{
+					fill_byte_in_index(messsage_block[index_in_arr64], bytes[index_byte + bytes_counter], bytes_counter);
+				}
 			}
 			if (bytes_remaining <= 8)
 			{
@@ -269,65 +280,65 @@ sha512::digest_t sha512::digest() const
 		}
 	}
 }
- void sha512::compress(const message_block_t& message_block, std::array<std::uint64_t, 8>& hash_values)
- {
-	 std::array<std::uint64_t, 80> message_schedule{ {0} };
+void sha512::compress(const message_block_t & message_block, std::array<std::uint64_t, 8>&hash_values)
+{
+	std::array<std::uint64_t, 80> message_schedule{ {0} };
 
-	 std::copy(message_block.begin(), message_block.end(), message_schedule.begin());
-	 for (int word_index = 16; word_index < 80; ++word_index)
-	 {
-		 message_schedule[word_index] =
-			 sha512::lowercase_sigma1(message_schedule[word_index - 2])
-			 + message_schedule[word_index - 7]
-			 + sha512::lowercase_sigma0(message_schedule[word_index - 15])
-			 + message_schedule[word_index - 16];
-	 }
+	std::copy(message_block.begin(), message_block.end(), message_schedule.begin());
+	for (int word_index = 16; word_index < 80; ++word_index)
+	{
+		message_schedule[word_index] =
+			sha512::lowercase_sigma1(message_schedule[word_index - 2LL])
+			+ message_schedule[word_index - 7LL]
+			+ sha512::lowercase_sigma0(message_schedule[word_index - 15LL])
+			+ message_schedule[word_index - 16LL];
+	}
 
-	 constexpr std::uint64_t constants[80]{
-		 0x428a2f98d728ae22ULL, 0x7137449123ef65cdULL, 0xb5c0fbcfec4d3b2fULL, 0xe9b5dba58189dbbcULL, 0x3956c25bf348b538ULL,
-		 0x59f111f1b605d019ULL, 0x923f82a4af194f9bULL, 0xab1c5ed5da6d8118ULL, 0xd807aa98a3030242ULL, 0x12835b0145706fbeULL,
-		 0x243185be4ee4b28cULL, 0x550c7dc3d5ffb4e2ULL, 0x72be5d74f27b896fULL, 0x80deb1fe3b1696b1ULL, 0x9bdc06a725c71235ULL,
-		 0xc19bf174cf692694ULL, 0xe49b69c19ef14ad2ULL, 0xefbe4786384f25e3ULL, 0x0fc19dc68b8cd5b5ULL, 0x240ca1cc77ac9c65ULL,
-		 0x2de92c6f592b0275ULL, 0x4a7484aa6ea6e483ULL, 0x5cb0a9dcbd41fbd4ULL, 0x76f988da831153b5ULL, 0x983e5152ee66dfabULL,
-		 0xa831c66d2db43210ULL, 0xb00327c898fb213fULL, 0xbf597fc7beef0ee4ULL, 0xc6e00bf33da88fc2ULL, 0xd5a79147930aa725ULL,
-		 0x06ca6351e003826fULL, 0x142929670a0e6e70ULL, 0x27b70a8546d22ffcULL, 0x2e1b21385c26c926ULL, 0x4d2c6dfc5ac42aedULL,
-		 0x53380d139d95b3dfULL, 0x650a73548baf63deULL, 0x766a0abb3c77b2a8ULL, 0x81c2c92e47edaee6ULL, 0x92722c851482353bULL,
-		 0xa2bfe8a14cf10364ULL, 0xa81a664bbc423001ULL, 0xc24b8b70d0f89791ULL, 0xc76c51a30654be30ULL, 0xd192e819d6ef5218ULL,
-		 0xd69906245565a910ULL, 0xf40e35855771202aULL, 0x106aa07032bbd1b8ULL, 0x19a4c116b8d2d0c8ULL, 0x1e376c085141ab53ULL,
-		 0x2748774cdf8eeb99ULL, 0x34b0bcb5e19b48a8ULL, 0x391c0cb3c5c95a63ULL, 0x4ed8aa4ae3418acbULL, 0x5b9cca4f7763e373ULL,
-		 0x682e6ff3d6b2b8a3ULL, 0x748f82ee5defb2fcULL, 0x78a5636f43172f60ULL, 0x84c87814a1f0ab72ULL, 0x8cc702081a6439ecULL,
-		 0x90befffa23631e28ULL, 0xa4506cebde82bde9ULL, 0xbef9a3f7b2c67915ULL, 0xc67178f2e372532bULL, 0xca273eceea26619cULL,
-		 0xd186b8c721c0c207ULL, 0xeada7dd6cde0eb1eULL, 0xf57d4f7fee6ed178ULL, 0x06f067aa72176fbaULL, 0x0a637dc5a2c898a6ULL,
-		 0x113f9804bef90daeULL, 0x1b710b35131c471bULL, 0x28db77f523047d84ULL, 0x32caab7b40c72493ULL, 0x3c9ebe0a15c9bebcULL,
-		 0x431d67c49c100d4cULL, 0x4cc5d4becb3e42b6ULL, 0x597f299cfc657e2aULL, 0x5fcb6fab3ad6faecULL, 0x6c44198c4a475817ULL
-	 };
-	 std::uint64_t a = hash_values[0];
-	 std::uint64_t b = hash_values[1];
-	 std::uint64_t c = hash_values[2];
-	 std::uint64_t d = hash_values[3];
-	 std::uint64_t e = hash_values[4];
-	 std::uint64_t f = hash_values[5];
-	 std::uint64_t g = hash_values[6];
-	 std::uint64_t h = hash_values[7];
-	 for (int word_index = 0; word_index < 80; ++word_index)
-	 {
-		 const std::uint64_t T1 = sha512::uppercase_sigma1(e) + sha512::choice(e, f, g) + h + constants[word_index] + message_schedule[word_index];
-		 const std::uint64_t T2 = sha512::uppercase_sigma0(a) + sha512::majority(a, b, c);
-		 h = g;
-		 g = f;
-		 f = e;
-		 e = d + T1;
-		 d = c;
-		 c = b;
-		 b = a;
-		 a = T1 + T2;
-	 }
-	 hash_values[0] += a;
-	 hash_values[1] += b;
-	 hash_values[2] += c;
-	 hash_values[3] += d;
-	 hash_values[4] += e;
-	 hash_values[5] += f;
-	 hash_values[6] += g;
-	 hash_values[7] += h;
- }
+	constexpr std::uint64_t constants[80]{
+		0x428a2f98d728ae22ULL, 0x7137449123ef65cdULL, 0xb5c0fbcfec4d3b2fULL, 0xe9b5dba58189dbbcULL, 0x3956c25bf348b538ULL,
+		0x59f111f1b605d019ULL, 0x923f82a4af194f9bULL, 0xab1c5ed5da6d8118ULL, 0xd807aa98a3030242ULL, 0x12835b0145706fbeULL,
+		0x243185be4ee4b28cULL, 0x550c7dc3d5ffb4e2ULL, 0x72be5d74f27b896fULL, 0x80deb1fe3b1696b1ULL, 0x9bdc06a725c71235ULL,
+		0xc19bf174cf692694ULL, 0xe49b69c19ef14ad2ULL, 0xefbe4786384f25e3ULL, 0x0fc19dc68b8cd5b5ULL, 0x240ca1cc77ac9c65ULL,
+		0x2de92c6f592b0275ULL, 0x4a7484aa6ea6e483ULL, 0x5cb0a9dcbd41fbd4ULL, 0x76f988da831153b5ULL, 0x983e5152ee66dfabULL,
+		0xa831c66d2db43210ULL, 0xb00327c898fb213fULL, 0xbf597fc7beef0ee4ULL, 0xc6e00bf33da88fc2ULL, 0xd5a79147930aa725ULL,
+		0x06ca6351e003826fULL, 0x142929670a0e6e70ULL, 0x27b70a8546d22ffcULL, 0x2e1b21385c26c926ULL, 0x4d2c6dfc5ac42aedULL,
+		0x53380d139d95b3dfULL, 0x650a73548baf63deULL, 0x766a0abb3c77b2a8ULL, 0x81c2c92e47edaee6ULL, 0x92722c851482353bULL,
+		0xa2bfe8a14cf10364ULL, 0xa81a664bbc423001ULL, 0xc24b8b70d0f89791ULL, 0xc76c51a30654be30ULL, 0xd192e819d6ef5218ULL,
+		0xd69906245565a910ULL, 0xf40e35855771202aULL, 0x106aa07032bbd1b8ULL, 0x19a4c116b8d2d0c8ULL, 0x1e376c085141ab53ULL,
+		0x2748774cdf8eeb99ULL, 0x34b0bcb5e19b48a8ULL, 0x391c0cb3c5c95a63ULL, 0x4ed8aa4ae3418acbULL, 0x5b9cca4f7763e373ULL,
+		0x682e6ff3d6b2b8a3ULL, 0x748f82ee5defb2fcULL, 0x78a5636f43172f60ULL, 0x84c87814a1f0ab72ULL, 0x8cc702081a6439ecULL,
+		0x90befffa23631e28ULL, 0xa4506cebde82bde9ULL, 0xbef9a3f7b2c67915ULL, 0xc67178f2e372532bULL, 0xca273eceea26619cULL,
+		0xd186b8c721c0c207ULL, 0xeada7dd6cde0eb1eULL, 0xf57d4f7fee6ed178ULL, 0x06f067aa72176fbaULL, 0x0a637dc5a2c898a6ULL,
+		0x113f9804bef90daeULL, 0x1b710b35131c471bULL, 0x28db77f523047d84ULL, 0x32caab7b40c72493ULL, 0x3c9ebe0a15c9bebcULL,
+		0x431d67c49c100d4cULL, 0x4cc5d4becb3e42b6ULL, 0x597f299cfc657e2aULL, 0x5fcb6fab3ad6faecULL, 0x6c44198c4a475817ULL
+	};
+	std::uint64_t a = hash_values[0];
+	std::uint64_t b = hash_values[1];
+	std::uint64_t c = hash_values[2];
+	std::uint64_t d = hash_values[3];
+	std::uint64_t e = hash_values[4];
+	std::uint64_t f = hash_values[5];
+	std::uint64_t g = hash_values[6];
+	std::uint64_t h = hash_values[7];
+	for (int word_index = 0; word_index < 80; ++word_index)
+	{
+		const std::uint64_t T1 = sha512::uppercase_sigma1(e) + sha512::choice(e, f, g) + h + constants[word_index] + message_schedule[word_index];
+		const std::uint64_t T2 = sha512::uppercase_sigma0(a) + sha512::majority(a, b, c);
+		h = g;
+		g = f;
+		f = e;
+		e = d + T1;
+		d = c;
+		c = b;
+		b = a;
+		a = T1 + T2;
+	}
+	hash_values[0] += a;
+	hash_values[1] += b;
+	hash_values[2] += c;
+	hash_values[3] += d;
+	hash_values[4] += e;
+	hash_values[5] += f;
+	hash_values[6] += g;
+	hash_values[7] += h;
+}

--- a/rsa_cpp/sha512.cpp
+++ b/rsa_cpp/sha512.cpp
@@ -4,24 +4,14 @@
 #include <stdexcept>
 #include <boost/endian/conversion.hpp>
 
-std::array<std::uint8_t, sha512::hash_digest_size_in_bytes> sha512::calculate_hash(const std::uint8_t* const message, const std::size_t len)
+// The size of the message in bits is put at the end of the final message_block.
+// There are 128 bits reserved there, so according to the standards regarding
+// SHA512, the largest message that SHA512 supports is of size 2^128-1 bits
+// which I assume to never receive as part of this function.
+
+void sha512::update(const std::uint8_t* const message, const std::size_t len)
 {
-	//the size of each message block in bits
-	constexpr int blocks_size_bits{ sha512::hash_digest_size_in_bits * 2 };
-
-	//the size of each message block in bytes
-	constexpr int blocks_size_bytes{ blocks_size_bits / 8 };
-
-	// The size of the message in bits is put at the end of the final message_block.
-	// There are 128 bits reserved there, so according to the standards regarding
-	// SHA512, the largest message that SHA512 supports is of size 2^128-1 bits
-	// which I assume to never receive as part of this function.
-	std::array<std::uint64_t, 8> current_hash_values{ {
-		0x6a09e667f3bcc908ULL, 0xbb67ae8584caa73bULL, 0x3c6ef372fe94f82bULL, 0xa54ff53a5f1d36f1ULL,
-		0x510e527fade682d1ULL, 0x9b05688c2b3e6c1fULL, 0x1f83d9abfb41bd6bULL, 0x5be0cd19137e2179ULL
-	} };
 	{
-		std::array<std::uint64_t, blocks_size_bits / 64> current_block;
 
 		{
 			// A boolean for whether the terminating 1 bit got put in the
@@ -90,6 +80,12 @@ std::array<std::uint8_t, sha512::hash_digest_size_in_bytes> sha512::calculate_ha
 		current_block[current_block.size() - 2] = static_cast<std::uint64_t>(static_cast<std::uint64_t>(len) >> (64 - 3) /*The overflow bits from earlier*/);
 		sha512::SHA512_compress(current_block, current_hash_values);
 	}
+}
+
+sha512::digest_t sha512::digest() const
+{
+
+
 	// Finally, now that we have the hash values inside of
 	// "current_hash_values" as 64 bits big endian.
 	// It's big endian because we originally loaded the
@@ -97,7 +93,7 @@ std::array<std::uint8_t, sha512::hash_digest_size_in_bytes> sha512::calculate_ha
 	// we'll convert the hash to bytes to avoid
 	// confusion over endianness.
 
-	std::array<std::uint8_t, sha512::hash_digest_size_in_bytes> final_hash;
+	sha512::digest_t final_hash;
 
 	for (int index = 0; index < static_cast<int>(current_hash_values.size()); ++index)
 	{
@@ -105,10 +101,11 @@ std::array<std::uint8_t, sha512::hash_digest_size_in_bytes> sha512::calculate_ha
 	}
 	return final_hash;
 }
- void sha512::copy_arr_bytes_into_arr_64_bits(const std::uint8_t* const bytes, const std::size_t num_bytes, std::uint64_t* const arr64)
+
+// Loading the bytes into the std::uint64 as big endian because
+// that's the convention when dealing with SHA512
+ void sha512::copy_arr_bytes_into_arr_64_bits(const std::uint8_t* const bytes, const std::size_t num_bytes, std::uint64_t* const arr64, const int num_bytes_already_taken)
 {
-	// Loading the bytes into the std::uint64 as big endian because
-	// that's the convention when dealing with SHA512
 	auto& load_big_or_little = boost::endian::load_big_u64;
 	if (num_bytes > 0)
 	{
@@ -135,11 +132,11 @@ std::array<std::uint8_t, sha512::hash_digest_size_in_bytes> sha512::calculate_ha
 		}
 	}
 }
- void sha512::SHA512_compress(const std::array<std::uint64_t, 16>& message_block, std::array<std::uint64_t, 8>& parameter_hash_values)
+ void sha512::compress()
  {
 	 std::array<std::uint64_t, 80> message_schedule;
 
-	 std::copy(message_block.begin(), message_block.end(), message_schedule.begin());
+	 std::copy(this->m_message_block.begin(), this->m_message_block.end(), message_schedule.begin());
 	 for (int word_index = 16; word_index < 80; ++word_index)
 	 {
 		 message_schedule[word_index] =
@@ -167,14 +164,14 @@ std::array<std::uint8_t, sha512::hash_digest_size_in_bytes> sha512::calculate_ha
 		 0x113f9804bef90daeULL, 0x1b710b35131c471bULL, 0x28db77f523047d84ULL, 0x32caab7b40c72493ULL, 0x3c9ebe0a15c9bebcULL,
 		 0x431d67c49c100d4cULL, 0x4cc5d4becb3e42b6ULL, 0x597f299cfc657e2aULL, 0x5fcb6fab3ad6faecULL, 0x6c44198c4a475817ULL
 	 };
-	 std::uint64_t a = parameter_hash_values[0];
-	 std::uint64_t b = parameter_hash_values[1];
-	 std::uint64_t c = parameter_hash_values[2];
-	 std::uint64_t d = parameter_hash_values[3];
-	 std::uint64_t e = parameter_hash_values[4];
-	 std::uint64_t f = parameter_hash_values[5];
-	 std::uint64_t g = parameter_hash_values[6];
-	 std::uint64_t h = parameter_hash_values[7];
+	 std::uint64_t a = this->m_hash_values[0];
+	 std::uint64_t b = this->m_hash_values[1];
+	 std::uint64_t c = this->m_hash_values[2];
+	 std::uint64_t d = this->m_hash_values[3];
+	 std::uint64_t e = this->m_hash_values[4];
+	 std::uint64_t f = this->m_hash_values[5];
+	 std::uint64_t g = this->m_hash_values[6];
+	 std::uint64_t h = this->m_hash_values[7];
 	 for (int word_index = 0; word_index < 80; ++word_index)
 	 {
 		 const std::uint64_t T1 = sha512::uppercase_sigma1(e) + sha512::choice(e, f, g) + h + constants[word_index] + message_schedule[word_index];
@@ -188,12 +185,12 @@ std::array<std::uint8_t, sha512::hash_digest_size_in_bytes> sha512::calculate_ha
 		 b = a;
 		 a = T1 + T2;
 	 }
-	 parameter_hash_values[0] += a;
-	 parameter_hash_values[1] += b;
-	 parameter_hash_values[2] += c;
-	 parameter_hash_values[3] += d;
-	 parameter_hash_values[4] += e;
-	 parameter_hash_values[5] += f;
-	 parameter_hash_values[6] += g;
-	 parameter_hash_values[7] += h;
+	 this->m_hash_values[0] += a;
+	 this->m_hash_values[1] += b;
+	 this->m_hash_values[2] += c;
+	 this->m_hash_values[3] += d;
+	 this->m_hash_values[4] += e;
+	 this->m_hash_values[5] += f;
+	 this->m_hash_values[6] += g;
+	 this->m_hash_values[7] += h;
  }

--- a/rsa_cpp/sha512.hpp
+++ b/rsa_cpp/sha512.hpp
@@ -118,16 +118,17 @@ private:
 	//
 	// All of the bytes in the 64-bit integer array that aren't direct
 	// targets to be overridden, are unaffected by this function's operation.
-	static void copy_arr_bytes_into_arr_64_bits(
+	static void copy_arr_bytes_into_message_block(
 		// Source array of bytes
 		const std::uint8_t* const bytes,
 		// Length of "bytes" array
-		const std::size_t num_bytes,
-		// Destination 64 bit array
-		std::uint64_t* const arr64,
-		// How many bytes are already used inside of the first element of arr64?
-		// The first used byte is the most significant one, in big-endian style.
-		const int num_bytes_already_taken);
+		const int num_bytes,
+		// Destination
+		message_block_t& messsage_block,
+		// How many bytes are already used inside of the entire message block
+		// The first used byte is the most significant one byte of the first
+		// element in the array, in big-endian style.
+		const int num_bytes_already_used_in_message_block);
 
 	static void compress(const message_block_t& message_block, std::array<std::uint64_t, 8>& hash_values);
 

--- a/rsa_cpp/sha512.hpp
+++ b/rsa_cpp/sha512.hpp
@@ -5,13 +5,57 @@
 
 class sha512
 {
-	//returns the hash size in bits
+	// The hash size in bits
 	static constexpr int hash_digest_size_in_bits{ 512 };
-	//returns the hash size in bytes
+	// The hash size in bytes
 	static constexpr int hash_digest_size_in_bytes{ hash_digest_size_in_bits / 8 };
+
+	// The size of each message block in bits
+	static constexpr int message_block_size_bits{ sha512::hash_digest_size_in_bits * 2 };
+
+	// The size of each message block in bytes
+	static constexpr int message_block_size_bytes{ message_block_size_bits / 8 };
+
+	// Current hash values, of the concatenation of all of the message
+	// blocks that we went through until now not including the current message block.
+	std::array<std::uint64_t, 8> m_hash_values{ {
+	0x6a09e667f3bcc908ULL, 0xbb67ae8584caa73bULL, 0x3c6ef372fe94f82bULL, 0xa54ff53a5f1d36f1ULL,
+	0x510e527fade682d1ULL, 0x9b05688c2b3e6c1fULL, 0x1f83d9abfb41bd6bULL, 0x5be0cd19137e2179ULL } };
+
+	// The partial message block that hasn't yet been accounted for in
+	// the summation m_hash_values.
+	// The assumption is that m_message_block will be "emptied" when full
+	// The variable "m_num_bytes_filled" keeps track of how full m_message_block is.
+	std::array<std::uint64_t, message_block_size_bits / 64> m_message_block;
+
+	// 1024 bits fills the entire 16 * 64bit message block
+	static constexpr int completely_full_message_block = 1024;
+
+	// The message block contains 64-bit integers but we're measuring the fullness level in
+	// bytes. The message block is filled in big endian order inside of each 64-bit integer.
+	// Meaning if "m_num_bytes_filled" then the 3 most significant bytes are set
+	// in the first element of "current_message_block".
+	int m_num_bytes_filled = 0;
+
 public:
-//calculates the sha512 hash
-	static std::array<std::uint8_t, hash_digest_size_in_bytes> calculate_hash(const std::uint8_t* const message, const std::size_t len);
+	sha512() = default;
+	sha512(const sha512&) = default;
+	sha512(sha512&&) = default;
+	sha512& operator=(const sha512&) = default;
+	sha512& operator=(sha512&&) = default;
+
+	sha512(const std::uint8_t* const data, const std::size_t len) { this->update(data, len); }
+
+	// Appends another part of the message to be concatenated.
+	// Even though that sounds expensive, the memory usage is constant.
+	void update(const std::uint8_t* const data, const std::size_t len);
+
+	using digest_t = std::array<std::uint8_t, hash_digest_size_in_bytes>;
+
+	// At any point you can ask for the hash of the concatenated data so far
+	digest_t digest() const;
+
+	~sha512() = default;
 private:
 	template <typename x_T, int amount>
 	static x_T rotater(const x_T& x)
@@ -64,7 +108,26 @@ private:
 		return (x & y) ^ (x & z) ^ (y & z);
 	}
 
-	static void copy_arr_bytes_into_arr_64_bits(const std::uint8_t* const bytes, const std::size_t num_bytes, std::uint64_t* const arr64);
-	//compresses the SHA512 message block
-	static void SHA512_compress(const std::array<std::uint64_t, 16>& message_block, std::array<std::uint64_t, 8>& parameter_hash_values);
+	// Helper function to copy elements from an array of bytes
+	// into an array of 64 bit unsigned integers in big-endian byte loading.
+	// That means that the first byte copies into the most significant
+	// byte of the first element of the 64 bit integer array etc.
+	//
+	// All of the bytes in the 64-bit integer array that aren't direct
+	// targets to be overridden, are unaffected by this function's operation.
+	static void copy_arr_bytes_into_arr_64_bits(
+		// Source array of bytes
+		const std::uint8_t* const bytes,
+		// Length of "bytes" array
+		const std::size_t num_bytes,
+		// Destination 64 bit array
+		std::uint64_t* const arr64,
+		// How many bytes are already used inside of the first element of arr64?
+		// The first used byte is the most significant one, in big-endian style.
+		const int num_bytes_already_taken);
+
+	// Consumes m_message_block and alters m_hash_values accordingly.
+	// Assumes that m_num_bytes_filled == completely_full_message_block
+	// Sets m_num_bytes_filled to 0
+	void compress();
 };


### PR DESCRIPTION
Gives ability for incremental computation of hash. Doesn't require providing the entire message at once as an array in contiguous memory.